### PR TITLE
Fix sidebar click on iPad

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useIsTouchDevice } from "@/hooks/use-touch-device";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -543,8 +544,9 @@ const SidebarMenuButton = React.forwardRef<
     },
     ref
   ) => {
-    const Comp = asChild ? Slot : "button";
-    const { isMobile, state } = useSidebar();
+  const Comp = asChild ? Slot : "button";
+  const { isMobile, state } = useSidebar();
+  const isTouch = useIsTouchDevice();
 
     const button = (
       <Comp
@@ -557,7 +559,7 @@ const SidebarMenuButton = React.forwardRef<
       />
     );
 
-    if (!tooltip) {
+    if (!tooltip || isTouch) {
       return button;
     }
 

--- a/src/hooks/use-touch-device.tsx
+++ b/src/hooks/use-touch-device.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+export function useIsTouchDevice() {
+  const [isTouch, setIsTouch] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    const hasTouch =
+      (typeof window !== "undefined" && "ontouchstart" in window) ||
+      (typeof navigator !== "undefined" && navigator.maxTouchPoints > 0);
+    setIsTouch(hasTouch);
+  }, []);
+
+  return isTouch;
+}
+


### PR DESCRIPTION
## Summary
- check if device supports touch
- skip sidebar menu tooltips on touch devices

## Testing
- `npm run lint` *(fails: `next` not found)*